### PR TITLE
refactor: port icon button display to grid widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -797,7 +797,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1814,7 +1814,7 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 [[package]]
 name = "iced"
 version = "0.10.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "iced_accessibility",
  "iced_core",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.10.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "bitflags 1.3.2",
  "iced_accessibility",
@@ -1855,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.7.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "futures",
  "iced_core",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.9.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1899,7 +1899,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.1.1"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "iced_accessibility",
  "iced_core",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.9.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1963,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.11.1"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.1.3"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -1999,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.10.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -2220,7 +2220,7 @@ checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6448b75e7628aef34b0dd8f6dffacde83933466f"
+source = "git+https://github.com/pop-os/libcosmic#971a1fa89cc9559b683a849274950c56ad937790"
 dependencies = [
  "apply",
  "ashpd",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.3.11"
-source = "git+https://github.com/DioxusLabs/taffy#65bedf128ec8cef40c1a21b6f141f2c771842cca"
+source = "git+https://github.com/DioxusLabs/taffy#120bb7a2e501822b324fd48de955450ebbba1c1a"
 dependencies = [
  "arrayvec 0.7.4",
  "grid",

--- a/src/buttons.rs
+++ b/src/buttons.rs
@@ -3,7 +3,7 @@
 
 use super::{App, Message};
 use cosmic::iced_core::Alignment;
-use cosmic::widget::{button, column, icon, row, text};
+use cosmic::widget::{button, column, grid, icon, row, text};
 use cosmic::Element;
 
 impl App
@@ -152,201 +152,178 @@ where
 }
 
 fn view_icon_buttons(icon: icon::Handle) -> impl Into<Element<'static, Message>> {
-    row()
-        .spacing(36)
-        // Without Labels
+    grid()
+        .column_alignment(Alignment::Center)
+        .column_spacing(24)
+        .row_alignment(Alignment::Center)
+        .row_spacing(36)
         .push(
-            column()
-                .spacing(24)
-                .align_items(Alignment::Center)
-                .push(
-                    button::icon(icon.clone())
-                        .extra_small()
-                        .on_press(Message::Clicked)
-                        .tooltip("Extra small icon button"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .on_press(Message::Clicked)
-                        .tooltip("Small icon button"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .medium()
-                        .on_press(Message::Clicked)
-                        .tooltip("Medium icon button"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .large()
-                        .on_press(Message::Clicked)
-                        .tooltip("Large icon button"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .extra_large()
-                        .on_press(Message::Clicked)
-                        .tooltip("Extra large icon button"),
-                ),
+            button::icon(icon.clone())
+                .extra_small()
+                .on_press(Message::Clicked)
+                .tooltip("Extra small icon button"),
         )
-        // With Labels
         .push(
-            column()
-                .spacing(24)
-                .align_items(Alignment::Center)
-                .push(
-                    button::icon(icon.clone())
-                        .extra_small()
-                        .on_press(Message::Clicked)
-                        .tooltip("Extra small icon button")
-                        .label("Label"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .on_press(Message::Clicked)
-                        .tooltip("Small icon button")
-                        .label("Label"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .medium()
-                        .on_press(Message::Clicked)
-                        .tooltip("Medium icon button")
-                        .label("Label"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .large()
-                        .on_press(Message::Clicked)
-                        .tooltip("Large icon button")
-                        .label("Label"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .extra_large()
-                        .on_press(Message::Clicked)
-                        .tooltip("Extra large icon button")
-                        .label("Label"),
-                ),
+            button::icon(icon.clone())
+                .extra_small()
+                .on_press(Message::Clicked)
+                .tooltip("Extra small icon button")
+                .label("Label"),
         )
-        // Disabled
         .push(
-            column()
-                .spacing(24)
-                .align_items(Alignment::Center)
-                .push(
-                    button::icon(icon.clone())
-                        .extra_small()
-                        .tooltip("Extra small icon button")
-                        .label("Label"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .tooltip("Small icon button")
-                        .label("Label"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .medium()
-                        .tooltip("Medium icon button")
-                        .label("Label"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .large()
-                        .tooltip("Large icon button")
-                        .label("Label"),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .extra_large()
-                        .tooltip("Extra large icon button")
-                        .label("Label"),
-                ),
+            button::icon(icon.clone())
+                .extra_small()
+                .tooltip("Extra small icon button")
+                .label("Label"),
         )
-        // Vertical layout
         .push(
-            column()
-                .spacing(24)
-                .align_items(Alignment::Center)
-                .push(
-                    button::icon(icon.clone())
-                        .extra_small()
-                        .on_press(Message::Clicked)
-                        .tooltip("Extra small icon button")
-                        .label("Label")
-                        .vertical(true),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .on_press(Message::Clicked)
-                        .tooltip("Small icon button")
-                        .label("Label")
-                        .vertical(true),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .medium()
-                        .on_press(Message::Clicked)
-                        .tooltip("Medium icon button")
-                        .label("Label")
-                        .vertical(true),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .large()
-                        .on_press(Message::Clicked)
-                        .tooltip("Large icon button")
-                        .label("Label")
-                        .vertical(true),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .extra_large()
-                        .on_press(Message::Clicked)
-                        .tooltip("Extra large icon button")
-                        .label("Label")
-                        .vertical(true),
-                ),
+            button::icon(icon.clone())
+                .extra_small()
+                .on_press(Message::Clicked)
+                .tooltip("Extra small icon button")
+                .label("Label")
+                .vertical(true),
         )
-        // Vertical disabled
         .push(
-            column()
-                .spacing(24)
-                .align_items(Alignment::Center)
-                .push(
-                    button::icon(icon.clone())
-                        .extra_small()
-                        .tooltip("Extra small icon button")
-                        .label("Label")
-                        .vertical(true),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .tooltip("Small icon button")
-                        .label("Label")
-                        .vertical(true),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .medium()
-                        .tooltip("Medium icon button")
-                        .label("Label")
-                        .vertical(true),
-                )
-                .push(
-                    button::icon(icon.clone())
-                        .large()
-                        .tooltip("Large icon button")
-                        .label("Label")
-                        .vertical(true),
-                )
-                .push(
-                    button::icon(icon)
-                        .extra_large()
-                        .tooltip("Extra large icon button")
-                        .label("Label")
-                        .vertical(true),
-                ),
+            button::icon(icon.clone())
+                .extra_small()
+                .tooltip("Extra small icon button")
+                .label("Label")
+                .vertical(true),
+        )
+        .insert_row()
+        .push(
+            button::icon(icon.clone())
+                .on_press(Message::Clicked)
+                .tooltip("Small icon button"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .on_press(Message::Clicked)
+                .tooltip("Small icon button")
+                .label("Label"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .tooltip("Small icon button")
+                .label("Label"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .on_press(Message::Clicked)
+                .tooltip("Small icon button")
+                .label("Label")
+                .vertical(true),
+        )
+        .push(
+            button::icon(icon.clone())
+                .tooltip("Small icon button")
+                .label("Label")
+                .vertical(true),
+        )
+        .insert_row()
+        .push(
+            button::icon(icon.clone())
+                .medium()
+                .on_press(Message::Clicked)
+                .tooltip("Medium icon button"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .medium()
+                .on_press(Message::Clicked)
+                .tooltip("Medium icon button")
+                .label("Label"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .medium()
+                .tooltip("Medium icon button")
+                .label("Label"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .medium()
+                .on_press(Message::Clicked)
+                .tooltip("Medium icon button")
+                .label("Label")
+                .vertical(true),
+        )
+        .push(
+            button::icon(icon.clone())
+                .medium()
+                .tooltip("Medium icon button")
+                .label("Label")
+                .vertical(true),
+        )
+        .insert_row()
+        .push(
+            button::icon(icon.clone())
+                .large()
+                .on_press(Message::Clicked)
+                .tooltip("Large icon button"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .large()
+                .on_press(Message::Clicked)
+                .tooltip("Large icon button")
+                .label("Label"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .large()
+                .tooltip("Large icon button")
+                .label("Label"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .large()
+                .on_press(Message::Clicked)
+                .tooltip("Large icon button")
+                .label("Label")
+                .vertical(true),
+        )
+        .push(
+            button::icon(icon.clone())
+                .large()
+                .tooltip("Large icon button")
+                .label("Label")
+                .vertical(true),
+        )
+        .insert_row()
+        .push(
+            button::icon(icon.clone())
+                .extra_large()
+                .on_press(Message::Clicked)
+                .tooltip("Extra large icon button"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .extra_large()
+                .on_press(Message::Clicked)
+                .tooltip("Extra large icon button")
+                .label("Label"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .extra_large()
+                .tooltip("Extra large icon button")
+                .label("Label"),
+        )
+        .push(
+            button::icon(icon.clone())
+                .extra_large()
+                .on_press(Message::Clicked)
+                .tooltip("Extra large icon button")
+                .label("Label")
+                .vertical(true),
+        )
+        .push(
+            button::icon(icon)
+                .extra_large()
+                .tooltip("Extra large icon button")
+                .label("Label")
+                .vertical(true),
         )
 }

--- a/src/typography.rs
+++ b/src/typography.rs
@@ -13,7 +13,7 @@ where
         static SAMPLE_TEXT: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
 
         grid()
-            .column_spacing(16)
+            .column_spacing(8)
             .row_spacing(32)
             // Header
             .push(text::heading("Text Style"))
@@ -22,9 +22,7 @@ where
             .push(text::heading("Weight"))
             .push(text::heading("Two-line Example"))
             .insert_row()
-            .push_with(divider::horizontal::default(), |item| {
-                item.width(5)
-            })
+            .push_with(divider::horizontal::default(), |cell| cell.width(6))
             // Title 1
             .insert_row()
             .push(text::title1("Title 1"))


### PR DESCRIPTION
Also fixes the missing divider on the typography page